### PR TITLE
Add configurable beam spacing control

### DIFF
--- a/assets/projects/circle-of-fifths/main.js
+++ b/assets/projects/circle-of-fifths/main.js
@@ -55,6 +55,7 @@
   let chordType = 'none';
   let looping = false;
   let beamCount = 1;
+  let beamSpacing = 6;
   let startNoteIndex = 3;
   let beams = [];
   let isPlaying = false;
@@ -69,15 +70,18 @@
   // ─── BEAMS ───
   function initBeams() {
     beams = [];
-    var spacing = 12 / beamCount;
     for (var b = 0; b < beamCount; b++) {
-      var start = (startNoteIndex + Math.round(b * spacing)) % 12;
+      var start = (startNoteIndex + b * beamSpacing) % 12;
       beams.push({
         startIndex: start,
         currentIndex: start,
         visitedPath: [start]
       });
     }
+  }
+
+  function updateSpacingVisibility() {
+    document.getElementById('beamSpacingRow').style.display = beamCount > 1 ? '' : 'none';
   }
 
   // ─── AUDIO ───
@@ -462,6 +466,14 @@
 
   document.getElementById('beamCountSelect').addEventListener('change', function () {
     beamCount = parseInt(this.value);
+    beamSpacing = Math.round(12 / beamCount);
+    document.getElementById('beamSpacingSelect').value = beamSpacing;
+    updateSpacingVisibility();
+    reset();
+  });
+
+  document.getElementById('beamSpacingSelect').addEventListener('change', function () {
+    beamSpacing = parseInt(this.value);
     reset();
   });
 
@@ -489,6 +501,7 @@
   // ─── INIT ───
   buildStartNoteSelect();
   buildTickMarks();
+  updateSpacingVisibility();
   initBeams();
   updateInfo();
   updateButtons();

--- a/projects/circle-of-fifths.html
+++ b/projects/circle-of-fifths.html
@@ -94,6 +94,23 @@
           </select>
         </div>
 
+        <div class="control-row" id="beamSpacingRow" style="display: none;">
+          <span class="control-label">Spacing</span>
+          <select id="beamSpacingSelect">
+            <option value="1">Perfect 5th</option>
+            <option value="2">Major 2nd</option>
+            <option value="3">Major 6th</option>
+            <option value="4">Major 3rd</option>
+            <option value="5">Major 7th</option>
+            <option value="6">Tritone</option>
+            <option value="7">Minor 2nd</option>
+            <option value="8">Minor 6th</option>
+            <option value="9">Minor 3rd</option>
+            <option value="10">Minor 7th</option>
+            <option value="11">Perfect 4th</option>
+          </select>
+        </div>
+
         <div class="cof-info-row">
           <span class="info-item">Bounce angle <strong id="angleDisplay">105°</strong></span>
           <span class="info-item">Notes visited <strong id="notesCountDisplay">12</strong></span>


### PR DESCRIPTION
Beam spacing dropdown appears when using multiple beams, showing the musical interval between each beam's starting position. Defaults to even spacing when beam count changes, but can be overridden to any interval.