### PR TITLE
Centralize Google Analytics and add tracking to all pages

### DIFF
--- a/assets/js/analytics.js
+++ b/assets/js/analytics.js
@@ -1,0 +1,13 @@
+// Google Analytics (gtag.js)
+(function () {
+  var id = 'G-MGRGJHJ4S9';
+  var script = document.createElement('script');
+  script.async = true;
+  script.src = 'https://www.googletagmanager.com/gtag/js?id=' + id;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', id);
+})();

--- a/gallery.html
+++ b/gallery.html
@@ -23,15 +23,7 @@
   <meta property="og:description" content="I'm a quantum research scientist looking for positions in the interface between the theory and physical realisation of useful qubits.">
 
   <link rel="stylesheet" href="main.css">
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MGRGJHJ4S9"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-MGRGJHJ4S9');
-  </script>
+  <script src="assets/js/analytics.js"></script>
   <script src="assets/js/cursor-effect.js"></script>
   <script src="assets/js/menu.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -23,15 +23,7 @@
   <meta property="og:description" content="Daniel Long is a physicist by background and a tech enthusiast specializing in the intersection between artificial intelligence and physics.">
 
   <link rel="stylesheet" href="main.css">
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MGRGJHJ4S9"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'G-MGRGJHJ4S9');
-  </script>
+  <script src="assets/js/analytics.js"></script>
   <script src="assets/js/cursor-effect.js"></script>
   <script src="assets/js/menu.js"></script>
 </head>

--- a/projects.html
+++ b/projects.html
@@ -47,6 +47,7 @@
 		/>
 
 		<link rel="stylesheet" href="main.css" />
+		<script src="assets/js/analytics.js"></script>
 		<script src="assets/js/cursor-effect.js"></script>
 		<script src="assets/js/menu.js"></script>
 	</head>

--- a/projects/ask-llms.html
+++ b/projects/ask-llms.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="A forum style interface for asking questions to a large language model.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/bass-practice.html
+++ b/projects/bass-practice.html
@@ -24,6 +24,7 @@
 
   <link rel="stylesheet" href="../main.css">
   <link rel="stylesheet" href="bass-practice.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/character-markov-chain.html
+++ b/projects/character-markov-chain.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="Character level Markov chain that generates text in the style of 'The Picture of Dorian Gray' by Oscar Wilde.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
   

--- a/projects/circle-of-fifths.html
+++ b/projects/circle-of-fifths.html
@@ -24,6 +24,7 @@
 
   <link rel="stylesheet" href="../main.css">
   <link rel="stylesheet" href="circle-of-fifths.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/clean-energy-wiki.html
+++ b/projects/clean-energy-wiki.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="A wiki examining clean energy technologies through fundamental physics: what energy gradients exist in nature, and what limits their conversion to useful work.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/cleanplate.html
+++ b/projects/cleanplate.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="Mobile app that aimed to enable food influencers to share the carbon impact of the food they promote.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/flight-offset.html
+++ b/projects/flight-offset.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="A simple site for estimating and offsetting carbon emissions from flying.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/mdnotes.html
+++ b/projects/mdnotes.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="A lightweight markdown reader and annotator PWA.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/othello-bot.html
+++ b/projects/othello-bot.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="Interactive Othello game with various AI opponents from random to minimax algorithms.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/second-order-cybernetics.html
+++ b/projects/second-order-cybernetics.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="A 12-episode podcast series tracing the transformation of cybernetics from a science of control into a science of participation.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/snn-benchmarks.html
+++ b/projects/snn-benchmarks.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="A site to track Spiking Neural Network (SNN) Benchmarks using results from leading research papers.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/projects/ticket-to-ride-ai.html
+++ b/projects/ticket-to-ride-ai.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="Ticket to Ride simulation to explore the game and develop an AI to play it.">
 
   <link rel="stylesheet" href="../main.css">
+  <script src="../assets/js/analytics.js"></script>
   <script src="../assets/js/cursor-effect.js"></script>
   <script src="../assets/js/menu.js"></script>
 </head>

--- a/reading.html
+++ b/reading.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="I'm a quantum research scientist looking for positions in the interface between the theory and physical realisation of superconducting qubits.">
 
   <link rel="stylesheet" href="main.css">
+  <script src="assets/js/analytics.js"></script>
   <script src="assets/js/cursor-effect.js"></script>
   <script src="assets/js/menu.js"></script>
 </head>

--- a/writing.html
+++ b/writing.html
@@ -23,6 +23,7 @@
   <meta property="og:description" content="I'm a quantum research scientist looking for positions in the interface between the theory and physical realisation of superconducting qubits.">
 
   <link rel="stylesheet" href="main.css">
+  <script src="assets/js/analytics.js"></script>
   <script src="assets/js/cursor-effect.js"></script>
   <script src="assets/js/menu.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Extracts inline GA snippet into a single shared `assets/js/analytics.js` that dynamically loads gtag
- Replaces the duplicated inline snippets in `index.html` and `gallery.html` with one `<script>` tag
- Adds GA tracking to the 15 pages that were previously untracked (projects.html, reading.html, writing.html, and all 12 project subpages)

## Test plan
- [x] Verified `analytics.js` loads correctly on root pages (index.html)
- [x] Verified `analytics.js` loads correctly on project subpages (projects/othello-bot.html)
- [x] Confirmed `dataLayer` is populated and gtag script is injected dynamically
- [x] No console errors on any pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)